### PR TITLE
Filter out of non-Java entries from Felix classpath

### DIFF
--- a/jps-plugin/src/net/chilicat/felixscr/intellij/jps/ScrProcessor.java
+++ b/jps-plugin/src/net/chilicat/felixscr/intellij/jps/ScrProcessor.java
@@ -46,7 +46,10 @@ public class ScrProcessor extends AbstractScrProcessor {
         JpsJavaDependenciesEnumerator enr = service.enumerateDependencies(Collections.singleton(moduleChunk.representativeTarget().getModule()));
         JpsJavaDependenciesRootsEnumerator classes = enr.productionOnly().withoutSdk().recursively().classes();
         for (File f : classes.getRoots()) {
-            classPath.add(f.getAbsolutePath());
+            // filter out non-Java classpath entries, because Felix fails processing them
+            if (f.getName().endsWith(".class") || f.getName().endsWith(".jar") || f.isDirectory()) {
+                classPath.add(f.getAbsolutePath());
+            }
         }
     }
 


### PR DESCRIPTION
When non-Java libraries are present in the module dependencies, then the plugin fails to compile such a module. This change fixes the issue.
